### PR TITLE
Add curl command to download latest release binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ optruck is a CLI tool for managing secrets and creating templates with 1Password
 ```bash
 go install github.com/yammerjp/optruck@latest
 ```
+   - OR download the latest release binary:
+```bash
+curl -L https://github.com/yammerjp/optruck/releases/download/v0.1.0/optruck_$(uname -s | tr '[:lower:]' '[:upper:]')_$(uname -m | sed 's/x86_64/amd64/').tar.gz | tar xz -C /usr/local/bin
+```
+   - OR download the latest release binary with sudo:
+```bash
+sudo curl -L https://github.com/yammerjp/optruck/releases/download/v0.1.0/optruck_$(uname -s | tr '[:lower:]' '[:upper:]')_$(uname -m | sed 's/x86_64/amd64/').tar.gz | sudo tar xz -C /usr/local/bin
+```
 
 ## Quick Start
 


### PR DESCRIPTION
Add examples to download the latest release binary in the `README.md`.

* Add a `curl` command example to download the latest release binary within the existing `go install` section.
* Add a `sudo curl` command example to download the latest release binary within the existing `go install` section.
* Handle `uname` command outputs in uppercase for Linux and Darwin.
* Handle `uname` command outputs for x86_64 and amd64 differences.
* Ensure the URL includes the latest version `v0.1.0`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yammerjp/optruck/pull/2?shareId=6130e1c0-e3a8-486c-9cbc-14cc5ca2c347).